### PR TITLE
Line 136 of CNN.py

### DIFF
--- a/2016-11_Seminar/Session 3 - Relation CNN/code/CNN.py
+++ b/2016-11_Seminar/Session 3 - Relation CNN/code/CNN.py
@@ -133,7 +133,7 @@ for epoch in xrange(nb_epoch):
 
     f1Sum = 0
     f1Count = 0
-    for targetLabel in xrange(1, max(yTest)):        
+    for targetLabel in xrange(1, max(yTest)+1):        
         prec = getPrecision(pred_test, yTest, targetLabel)
         rec = getPrecision(yTest, pred_test, targetLabel)
         f1 = 0 if (prec+rec) == 0 else 2*prec*rec/(prec+rec)


### PR DESCRIPTION
Current -> for targetLabel in xrange(1, max(yTest)): 
Proposed change -> for targetLabel in xrange(1, max(yTest)+1): 

Here, we are iterating over all categories which are numbered from 0 to 18 (inclusive). 
Zero is ignored since it is "Other" category I guess. 
To incorporate the highest category number 18, it should be 
 xrange(1, max(yTest)+1)